### PR TITLE
Implement fallback schedule when solver infeasible

### DIFF
--- a/initial_assignment.py
+++ b/initial_assignment.py
@@ -260,6 +260,8 @@ def solve_initial_model(request_csv_path: str | Path = REQUEST_CSV_PATH) -> pd.D
         print(
             f"No feasible solution found (status: {solver.StatusName(status)})."
         )
+        # Fallback: assign all rest days to avoid invalid blanks
+        df_result.loc[:, :] = "休"
     df_result.to_csv("temp_shift.csv", encoding="utf-8-sig")
 
     return df_result

--- a/refine_schedule.py
+++ b/refine_schedule.py
@@ -159,5 +159,14 @@ def optimize_final_schedule(
                     if solver.Value(x[(n, d, s)]):
                         df_result.loc[nurse, f"day_{d}"] = code
                         break
+    else:
+        # If optimization failed, keep the initial solution or fill rests
+        print(
+            f"Final optimization failed (status: {solver.StatusName(status)})."
+        )
+        if initial_df is not None:
+            df_result[:] = initial_df
+        else:
+            df_result.loc[:, :] = "休"
 
     return df_result


### PR DESCRIPTION
## Summary
- handle infeasible solver cases in `solve_initial_model`
- fill all days with rest shifts if optimization fails
- keep initial solution if final refinement fails

## Testing
- `python main.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884e4194f348324a5aea6522333a090